### PR TITLE
Remove version info on _pydelatin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,10 +190,4 @@ PYBIND11_MODULE(_pydelatin, m) {
         .def("getError", &PydelatinTriangulator::getError)
         .def("run", &PydelatinTriangulator::run)
         ;
-
-#ifdef VERSION_INFO
-    m.attr("__version__") = VERSION_INFO;
-#else
-    m.attr("__version__") = "dev";
-#endif
 }


### PR DESCRIPTION
The `VERSION_INFO` was having problems with Windows builds. See https://github.com/conda-forge/pydelatin-feedstock/pull/3#issuecomment-712466314. Since I use a Python wrapper around the pybind11 `_pydelatin` module, I don't need to attach version information to the `_pydelatin.PydelatinTriangulator` class

cc @davidbrochart 