### PR TITLE
Fix ssize_t on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ struct PydelatinTriangulator {
     void setData(const py::array_t<float> &data_) {
       // x must have ndim = 1; can be non-writeable
       auto r = data_.unchecked<1>();
-      ssize_t size = r.shape(0);
+      Py_ssize_t size = r.shape(0);
 
       std::vector<float> data__(size);
 


### PR DESCRIPTION
The [conda-forge build for python3.10 fails on Windows](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=405860&view=logs&jobId=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&j=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&t=3cc4a9ed-60e1-5810-6eb3-5f9cd4a26dba) with:
```
src/main.cpp(45): error C2065: 'ssize_t': undeclared identifier
```
It looks like `ssize_t` has to be replaced with `Py_ssize_t` (see e.g. https://github.com/jpype-project/jpype/issues/1009 and https://github.com/jpype-project/jpype/pull/1011).