### PR TITLE
Build Python 3.12 and 3.13 wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -60,7 +60,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.2
+      uses: pypa/cibuildwheel@v2.20.0
       env:
         # From rio-color here:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3


### PR DESCRIPTION
This PR addresses the issue mentioned [in this comment](https://github.com/kylebarron/pydelatin/pull/26#issuecomment-2302739302). 

#### Issue
> When using [`hatch`](https://hatch.pypa.io/latest/) to install `pydelatin` on my M1 Mac, I got the following error (Not sure > why, it works with system `pip`):
> 
> ```
> [...]
> ERROR: Failed building wheel for pydelatin
> ERROR: Could not build wheels for pydelatin, which is required to install pyproject.toml-based projects
> ```
> 
> Installing `glm` and adding it to the `PATH` worked fine:
> 
> ```
> brew install glm 
> export CPLUS_INCLUDE_PATH=$(brew --prefix glm)/include:$CPLUS_INCLUDE_PATH
> ```

#### Cause
I was not getting a wheel because I was using Python 3.12, for which wheels were not built with the old version of `cibuildwheel`.

#### Fix
I updated `pypa/cibuildwheel`.

#### Notes
- I successfully built the wheels running the workflow locally using [`act`](https://github.com/nektos/act) (with the publishing part commented out):

  ```
  act -P macos-11=-self-hosted -W .github/workflows/build-wheels.yml
  ```